### PR TITLE
Run CI with unlocked deps as well as with locked deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
           otp-version: ${{matrix.versions.otp}}
           elixir-version: ${{matrix.versions.elixir}}
 
+      - name: Unlock Mix Dependencies
+        if: matrix.mix_lock == 'without_mix_lock'
+        run: mix deps.unlock --all
+
       - name: Set cache key
         id: set_cache_key
         run: |
@@ -63,12 +67,8 @@ jobs:
           path: deps
           key: mix-${{ steps.set_cache_key.outputs.cache_key }}-v1
 
-      - name: Unlock Mix Dependencies
-        if: matrix.mix_lock == 'without_mix_lock'
-        run: mix deps.unlock --all
-
       - name: Install Mix Dependencies
-        if: steps.mix-cache.outputs.cache-hit != 'true' || matrix.mix_lock == 'without_mix_lock'
+        if: steps.mix-cache.outputs.cache-hit != 'true'
         run: mix deps.get
 
       - name: Build Project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,30 +5,36 @@ on:
     branches: [ main ]
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 2,6'
 
 jobs:
   test:
+    name: Text (Elixir ${{matrix.versions.elixir}}, OTP ${{matrix.versions.otp}}, ${{matrix.mix_lock}}, ${{matrix.linting}})
     runs-on: ubuntu-20.04
     continue-on-error: false
     strategy:
       fail-fast: false
       matrix:
-        include:
+        versions:
           - elixir: '1.13.2'
             otp: '24.1'
-            current_version: false
+            linting: 'without_linting'
           - elixir: '1.14.0'
             otp: '25.0'
-            current_version: false
+            linting: 'without_linting'
           - elixir: '1.15.0'
             otp: '26.0'
-            current_version: true
+            linting: 'with_linting'
           - elixir: '1.16.0'
             otp: '26.2'
-            current_version: true
+            linting: 'with_linting'
           - elixir: '1.17.0'
             otp: '27.0'
-            current_version: true
+            linting: 'with_linting'
+        mix_lock: ['with_mix_lock', 'without_mix_lock']
+        exclude:
+          - mix_lock: ${{ github.event.schedule && 'with_mix_lock' }}
 
     steps:
       - name: Checkout code
@@ -37,8 +43,8 @@ jobs:
       - name: Use Elixir
         uses: erlef/setup-beam@a34c98fd51e370b4d4981854aba1eb817ce4e483
         with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
+          otp-version: ${{matrix.versions.otp}}
+          elixir-version: ${{matrix.versions.elixir}}
 
       - name: Set cache key
         id: set_cache_key
@@ -57,8 +63,12 @@ jobs:
           path: deps
           key: mix-${{ steps.set_cache_key.outputs.cache_key }}-v1
 
+      - name: Unlock Mix Dependencies
+        if: matrix.mix_lock == 'without_mix_lock'
+        run: mix deps.unlock --all
+
       - name: Install Mix Dependencies
-        if: steps.mix-cache.outputs.cache-hit != 'true'
+        if: steps.mix-cache.outputs.cache-hit != 'true' || matrix.mix_lock == 'without_mix_lock'
         run: mix deps.get
 
       - name: Build Project
@@ -97,11 +107,11 @@ jobs:
 
       - name: Run Dialyzer
         run: mix dialyzer
-        if: ${{ matrix.current_version }}
+        if: ${{ matrix.versions.linting == 'with_linting' && matrix.mix_lock == 'with_mix_lock' }}
 
       - name: Run format check
         run: mix format --check-formatted
-        if: ${{ matrix.current_version }}
+        if: ${{ matrix.versions.linting == 'with_linting' && matrix.mix_lock == 'with_mix_lock' }}
 
   all_tests_passing:
     if: ${{ always() }}


### PR DESCRIPTION
https://hexdocs.pm/elixir/library-guidelines.html#dependency-handling recommends:

> The best practice of handling mix.lock file therefore would be to keep it in VCS, and run two different Continuous Integration (CI) workflows: the usual deterministic one, and another one, that starts with mix deps.unlock --all and always compiles your library and runs tests against latest versions of dependencies. The latter one might be even run nightly or otherwise recurrently to stay notified about any possible issue in regard to dependencies updates.