### PR TITLE
Fix smoke tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
         uses: nanasess/setup-chromedriver@v2
       - run: |
           export DISPLAY=:99
-          chromedriver &
+          chromedriver --port=9515 &
 
       - name: Set up demo projects
         run: cd demo/demo_hound && mix deps.get && cd ../demo_wallaby && mix deps.get


### PR DESCRIPTION
One of the latest Chromedriver updates causes it to no longer start on port 9515 like hound expects it to.